### PR TITLE
fix: read correctly file paths containing spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ MPlayer.prototype = _.extend({
         this.player.cmd('stop');
 
         this.setOptions(options);
-        this.player.cmd('loadfile', [file]);
+        this.player.cmd('loadfile', ['"' + file + '"']);
 
         this.status.playing = true;
     },
@@ -95,7 +95,7 @@ MPlayer.prototype = _.extend({
         this.player.cmd('stop');
 
         this.setOptions(options);
-        this.player.cmd('loadlist', [file]);
+        this.player.cmd('loadlist', ['"' + file + '"']);
 
         this.status.playing = true;
     },


### PR DESCRIPTION
Hi!

I tried using this module and stumbled as soon as I tried opening a file which had spaces in its filename. This fixes the problem by passing the filename as a string enclosed by quotes.
