### PR TITLE
Permits pass extra args to mplayer

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2,6 +2,7 @@ var spawn = require('child_process').spawn,
     EventEmitter = require('events').EventEmitter.prototype,
     _ = require('lodash');
 
+var defaultArgs = ['-msglevel', 'global=6', '-msglevel', 'cplayer=4', '-idle', '-slave', '-fs', '-noborder'];
 var Player = function(options) {
     this.options = options;
     this.spawn();
@@ -9,9 +10,15 @@ var Player = function(options) {
 
 Player.prototype = _.extend({
     spawn: function() {
-        var instance = spawn('mplayer',
-            ['-msglevel', 'global=6', '-msglevel', 'cplayer=4', '-idle', '-slave', '-fs', '-noborder']
-        );
+        var args = [];
+
+        if(typeof this.options.args === 'string') {
+            args = this.options.args.split(' ');
+        } else if(Array.isArray(this.options.args)) {
+            args = this.options.args
+        }
+
+        var instance = spawn('mplayer', defaultArgs.concat(args));
 
         this.setStatus();
 


### PR DESCRIPTION
Very useful in some cases

**Example**

```
    var player = new Mplayer({
        args: '-fstype _NET_STATE_FULLSCREEN -rootwin -geometry 800x600+0+0'
    });
```
