### PR TITLE
Stopping the player sets the playing state to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ MPlayer.prototype = _.extend({
     },
     stop: function() {
         this.player.cmd('stop');
+        this.status.playing = false;
     },
     seek: function(seconds) {
         this.player.cmd('seek', [seconds, 2]);


### PR DESCRIPTION
I think this goes along with the design choice of having a separate playing status variable. I have realized, that it will be set to false at some point, but with this it is set immediately.
