### PR TITLE
Emit EOF code when player stops

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ var MPlayer = function(options) {
         this.emit('start');
     }.bind(this));
 
-    this.player.on('playstop', function() {
+    this.player.on('playstop', function(code) {
         if(options.verbose) {
-            console.log('player.stop');
+            console.log('player.stop', code);
         }
-        this.emit('stop')
+        this.emit('stop', code)
     }.bind(this));
 
     var pauseTimeout,

--- a/lib/player.js
+++ b/lib/player.js
@@ -105,7 +105,13 @@ Player.prototype = _.extend({
         }
 
         if(data.indexOf('EOF code:') > -1) {
-            this.emit('playstop');
+            var codeStart, code;
+
+            codeStart = data.indexOf('code:') + 5;
+            code = data.substr(codeStart, 2).trim();
+            code = parseInt(code, 10);
+
+            this.emit('playstop', code);
             this.setStatus();
         }
 

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ player.openPlaylist('http://www.radio.com/radio-stream.pls', {
 * **start** - triggered once an asset playback has started
 * **play** - triggered when playback is resumed
 * **pause** - triggered when playback is paused
-* **stop** - triggered when an asset has finished playing
+* **stop** - < Number > EOF code - triggered when an asset has finished playing
 * **status** < Object > status - triggered whenever player status changes
 The `status` object has the following properties:
 ```javascript


### PR DESCRIPTION
Use case: I want to skip ahead to the next file when it reaches the end, but do nothing when the user skips ahead or stops the player.

Mplayer emits different EOF code's when a file is stopped. This PR emits that code as argument as part of the stop event. This enables a robust solution for the above use case; playing the next file only when EOF code === 1.