### PR TITLE
Fix: add duration to status for audio files

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,9 @@ var MPlayer = function(options) {
 
 MPlayer.prototype = _.extend({
     setOptions: function(options) {
-        if(options && options.length) {
-            options.forEach(function(value, key) {
-                this.player.cmd('set_property', [key, value]);
+        if(options && Object.keys(options).length) {
+          Object.keys(options).forEach(function(key) {
+                this.player.cmd('set_property', [key, options[key]]);
             }.bind(this));
         }
     },

--- a/lib/player.js
+++ b/lib/player.js
@@ -131,12 +131,17 @@ Player.prototype = _.extend({
             this.emit('timechange', time)
         }
 
-        if(data.indexOf('ANS_LENGTH') !== -1 && data.indexOf('ANS_VO_FULLSCREEN') !== -1 && data.indexOf('ANS_SUB_VISIBILITY') !== -1) {
-            this.setStatus({
-                duration: parseFloat(data.match(/ANS_LENGTH=([0-9\.]*)/)[1]),
-                fullscreen: (parseInt(data.match(/ANS_VO_FULLSCREEN=([01])/)[1]) === 1),
-                subtitles: (parseInt(data.match(/ANS_SUB_VISIBILITY=([01])/)[1]) === 1)
-            });
+        if(data.indexOf('ANS_LENGTH') !== -1 || data.indexOf('ANS_VO_FULLSCREEN') !== -1 || data.indexOf('ANS_SUB_VISIBILITY') !== -1) {
+            var status = {};
+
+            if(data.indexOf('ANS_LENGTH') !== -1)
+                status.duration = parseFloat(data.match(/ANS_LENGTH=([0-9\.]*)/)[1]);
+            if(data.indexOf('ANS_VO_FULLSCREEN') !== -1)
+                status.fullscreen = (parseInt(data.match(/ANS_VO_FULLSCREEN=([01])/)[1]) === 1);
+            if(data.indexOf('ANS_SUB_VISIBILITY') !== -1)
+                status.subtitles = (parseInt(data.match(/ANS_SUB_VISIBILITY=([01])/)[1]) === 1);
+
+            this.setStatus(status);
         }
     },
     onError: function(error) {


### PR DESCRIPTION
Without this, the duration in the *status* object is 0 for audio files. Now the correct duration is displayed. For video files, it shouldn't matter anyways.