### PR TITLE
Change regex which retrieves file name

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -92,7 +92,7 @@ Player.prototype = _.extend({
         }
 
         if(data.indexOf('Playing ') !== -1) {
-            var file = data.match(/Playing\s(.+?)\.\s/)[1];
+            var file = data.match(/Playing\s(.{1,})\./)[1];
             this.setStatus(false);
             this.setStatus({
                 filename: file


### PR DESCRIPTION
This regex fixex issue with 'fileName' field in 'status' object. Current regex doesn't handle file names like this: 'artist_albumName 01. song.mp3'.